### PR TITLE
Fix helm v3.0.0 chart error on install (#1459)

### DIFF
--- a/charts/voyager/templates/deployment.yaml
+++ b/charts/voyager/templates/deployment.yaml
@@ -120,7 +120,7 @@ spec:
       - hostPath:
           path: {{ .Values.persistence.hostPath | quote }}
         name: cloudconfig
-{{- end -}}
+{{- end }}
 {{- if .Values.templates.cfgmap }}
       - configMap:
           name: {{ .Values.templates.cfgmap }}


### PR DESCRIPTION
Fix YAML parse error converting YAML to JSON on line 82.

> `Error: YAML parse error on voyager/templates/deployment.yaml: error converting YAML to JSON: yaml: line 82: mapping values are not allowed in this contex`